### PR TITLE
Fix two potential parse-error causing problems

### DIFF
--- a/TinyXML.cpp
+++ b/TinyXML.cpp
@@ -193,7 +193,7 @@ void TinyXML::action(uint8_t ch, uint8_t actionType)
     checkTagBufferPtr = 0;
     break;
   case addtochktagname:
-    if (tagBufferPtr < CHECKTAGMAX-2) checkTagBuffer[checkTagBufferPtr++] = ch;
+    if (checkTagBufferPtr < CHECKTAGMAX-2) checkTagBuffer[checkTagBufferPtr++] = ch;
     else action(ch, error);
     break;
   case checkremovelasttag:

--- a/TinyXML.cpp
+++ b/TinyXML.cpp
@@ -54,7 +54,7 @@ void TinyXML::processChar(uint8_t ch)
     switch ( chToParse )
     {
     case whiteSpace:
-      if (ch == ' ' || ch == '\t' || ch == '\n' | ch == '\r') bMatch=true;
+      if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') bMatch=true;
       break;
     case alpha:
       if (isAlpha(ch))  bMatch=true;


### PR DESCRIPTION
This fixes two problems:

Deeply nested tags were failing to close, because we were checking the length of the main path-based tag buffer against the limit for the individual 'check' tag buffer. This was causing an error as soon as the parser encountered the first character of the closing tag name if the main path-based tag buffer was longer than the checktag buffer's limit.

Fixes a typoed '||' - or (in the code as '|' - bitwise or) that was causing '\r' to not be included as a whitespace character.