### PR TITLE
Make callback bind-able

### DIFF
--- a/TinyXML.h
+++ b/TinyXML.h
@@ -2,7 +2,7 @@
 #define TinyXML_h
 
 #include <inttypes.h>
-typedef void (*XMLcallback) (uint8_t errorflag, char* nameBuffer,  uint16_t namebuflen, char* dataBuffer,  uint16_t databuflen);
+typedef std::function<void(uint8_t errorflag, char* nameBuffer,  uint16_t namebuflen, char* dataBuffer,  uint16_t databuflen)> XMLcallback;
 
 #define isAlpha(ch) ((ch >= 'A' && ch <= 'Z') || (ch>='a' && ch<='z'))
 #define isNumeric(ch) (ch >= '0' && ch <= '9')

--- a/examples/NextBusLambda/NextBusLambda.ino
+++ b/examples/NextBusLambda/NextBusLambda.ino
@@ -1,0 +1,238 @@
+// -------------------------------------------------------------------------
+// NextBus transit display using ESP8266 WiFi microcontroller and Adafruit
+// 7-segment displays. Uses the following parts:
+//   - Adafruit Feather HUZZAH with ESP8266 WiFi (Adafruit #2821) -OR-
+//   - Adafruit HUZZAH ESP8266 Breakout (#2471) (requires FTDI cable)
+//   - Adafruit 0.56" 4-Digit 7-Segment Display (878, 879, 880, 881 or 1002)
+//     1 to 8 displays can be used, one per transit stop & line.
+//
+// Requires TinyXML library: https://github.com/adafruit/TinyXML
+//
+// This shows the next tracked & predicted arrival time for each transit
+// line and stop listed below, one per display (or next 2 arrivals if both
+// can fit on the 4-digit display with a space in-between).  As written,
+// this discards arrivals below a certain time threshold (can't safely be
+// reached in time) and shows only whole minutes; it does not count down
+// seconds. Intended to be a convenience and not a stress-inducing thing.
+// -------------------------------------------------------------------------
+
+#include <ESP8266WiFi.h>
+#include <TinyXML.h>
+#include <Wire.h>
+#include <Adafruit_LEDBackpack.h>
+
+// CONFIGURABLE GLOBAL STUFF -----------------------------------------------
+
+char ssid[] = "NETWORK_NAME",     // WiFi network name
+     pass[] = "NETWORK_PASSWORD", // WiFi network password
+     host[] = "webservices.nextbus.com";
+
+#define POLL_INTERVAL 2 // Time between searches (minutes)
+#define MIN_TIME      5 // Skip arrivals sooner than this (minutes)
+#define READ_TIMEOUT 15 // Cancel query if no data received (seconds)
+
+struct {
+  const uint8_t     addr;          // I2C address of display
+  const char       *agency;        // Get these using routefinder.py script
+  const char       *route;
+  const char       *stopID;
+  uint32_t          lastQueryTime; // Time of last query (millis())
+  uint32_t          seconds[2];    // Most recent predictions from server
+  Adafruit_7segment display;       // 7segment initialized at runtime
+} stops[] = {
+  { 0x70, "actransit", "210", "0702640" }, // Ohlone College
+  { 0x71, "actransit", "210", "0702630" }, // Union Landing
+  { 0x72, "actransit", "232", "0704440" }, // Fremont BART
+  { 0x73, "actransit", "232", "0704430" }  // NewPark Mall
+};
+
+// For basic use as-is, shouldn't need to edit below this line -------------
+
+#define NUM_STOPS (sizeof(stops) / sizeof(stops[0]))
+
+WiFiClient client;
+TinyXML    xml;
+uint8_t    buffer[150]; // For XML decoding
+uint8_t    s=NUM_STOPS; // Stop # currently being searched
+uint32_t   lastConnectTime = -(POLL_INTERVAL * 60000L); // neg on purpose!
+uint32_t   seconds[2];
+
+// UTILITY FUNCTIONS -------------------------------------------------------
+
+// Update 7-segment I2C display(s) with arrival predictions
+void refresh(void) {
+  uint32_t t, dt;
+  int16_t  p[2], m; // Prediction times (in minutes)
+  uint8_t  i, j, k, idx[] = { 0, 1, 3, 4 }; // 7-segment digit indices
+
+  yield(); // Handle WiFi events
+
+  for(i=0; i<NUM_STOPS; i++) { // For each stop...
+    // Time difference (seconds) since last query
+    dt = ((t = millis()) - stops[i].lastQueryTime + 500) / 1000;
+    // Convert predictions (stops[i].seconds, up to 2, sorted) to minutes
+    memset(p, 0, sizeof(p));       // Assume nothing
+    for(j=k=0; j<2; j++) {         // For each possible prediction...
+      if(stops[i].seconds[j]) {    // Prediction available?
+        int32_t s = (stops[i].seconds[j] - dt); // Possibly negative
+        if(s >= (MIN_TIME * 60)) { // Above min time threshold?
+          m = s / 60;              // Seconds -> minutes
+          if(m > 99) m = 99;       // Clip to 2 digits
+          p[k++] = m;              // Store
+        }
+      }
+    }
+
+    if(!k) {
+      // No current predictions for this stop. Display '----'
+      for(j=0; j<4; j++) {
+        stops[i].display.writeDigitRaw(idx[j], 0b01000000);
+      }
+    } else {
+      stops[i].display.clear();
+      // If two predictions for this stop, and if earlier prediction
+      // is 10 minutes or more, don't show the second prediction (it
+      // won't fit on display). Two predictions are shown ONLY if
+      // both will fit with a blank digit between them.
+      if(p[0] >= 10) p[1] = 0;
+
+      if(p[1]) {
+        stops[i].display.print(p[1]); // 2nd prediction on right
+        stops[i].display.writeDigitNum(0, p[0], false); // 1st on left
+      } else {
+        // Single prediction sorta left-ish justified on digits 0 & 1
+        if(p[0] >= 10) stops[i].display.writeDigitNum(0, p[0] / 10, false);
+        stops[i].display.writeDigitNum(1, p[0] % 10, false);
+      }
+    }
+
+    stops[i].display.writeDisplay();
+
+    // If this stop is currently being searched, pulse brightness
+    if(i == s) {
+      j = t >> 6; // ~1/16 sec
+      if(j & 0x10) stops[i].display.setBrightness(      j & 0xF);
+      else         stops[i].display.setBrightness(15 - (j & 0xF));
+    } else         stops[i].display.setBrightness(k ? 15 : 1);
+  }
+}
+
+// ONE-TIME INITIALIZATION -------------------------------------------------
+
+void setup(void) {
+  Serial.begin(115200);
+  Serial.println("NextBus Tracker");
+  Wire.begin();
+
+  // TinyXML invokes this callback as elements are parsed in XML,
+  // allowing us to pick out just the tidbits of interest rather than
+  // dynamically allocating and then traversing a whole brobdingnagian
+  // tree structure; very Arduino-friendly!
+  // As written here, this looks for XML tags named "seconds" and extracts
+  // the accompanying value (a predicted bus arrival time, in seconds).
+  // If it's longer than our minimum threshold, the least two values are
+  // sorted and saved (sooner time first); one or both may be zero if
+  // further predictions are not available. Results are stored in global
+  // two-element int array named 'seconds' and moved to stop struct later.
+
+  xml.init((uint8_t *)buffer, sizeof(buffer), [](uint8_t statusflags, char* tagName, uint16_t tagNameLen, char* data, uint16_t dataLen) {
+    if((statusflags & STATUS_ATTR_TEXT) && !strcasecmp(tagName, "seconds")) {
+      uint32_t t = atoi(data); // Prediction in seconds (0 if gibberish)
+      Serial.print(t); Serial.println(" seconds");
+      if(t >= (MIN_TIME * 60)) {        // Above our "too soon" threshold?
+        if(!seconds[0]) {               //  No predictions yet?
+          seconds[0] = t;               //   Save in slot 0, done
+        } else {                        //  Else 1-2 existing predictions...
+          if(t <= seconds[0]) {         // New time sooner than slot 0?
+            seconds[1] = seconds[0];    //  Move 0 up to 1 (old 1 discarded)
+            seconds[0] = t;             //  Store new time in 0
+          } else if(!seconds[1] ||      // Slot 1 empty?
+                   (t <= seconds[1])) { // Or new time sooner than 1?
+            seconds[1] = t;             //  Store new time in slot 1
+          }                             // Else discard
+          if(seconds[0] == seconds[1]) seconds[1] = 0; // If equal, delete 1
+        }
+      }
+    }
+  });
+
+  for(uint8_t i=0; i<NUM_STOPS; i++) {
+    stops[i].display.begin(stops[i].addr);
+    stops[i].display.clear();
+    stops[i].display.writeDisplay();
+    stops[i].lastQueryTime = 0;
+    memset(stops[i].seconds, 0, sizeof(stops[i].seconds));
+  }
+}
+
+// MAIN LOOP ---------------------------------------------------------------
+
+void loop(void) {
+  uint32_t t;
+  int      c;
+  uint8_t  b = 0;
+  boolean  timedOut;
+
+  while(((t = millis()) - lastConnectTime) < (POLL_INTERVAL * 60000L)) {
+    refresh();
+  }
+  lastConnectTime = t;
+
+  if(WiFi.status() != WL_CONNECTED) {
+    Serial.print("WiFi connecting..");
+    WiFi.begin(ssid, pass);
+    // Wait up to 1 minute for connection...
+    for(c=0; (c < 60) && (WiFi.status() != WL_CONNECTED); c++) {
+      Serial.write('.');
+      for(t = millis(); (millis() - t) < 1000; refresh());
+    }
+    if(c >= 60) { // If it didn't connect within 1 min
+      Serial.println("Failed. Will retry...");
+      return;
+    }
+    Serial.println("OK!");
+    delay(10000); // Pause before hitting it with queries & stuff
+  }
+
+  for(s=0; s<NUM_STOPS; s++) {
+    Serial.print("Stop #");
+    Serial.println(stops[s].stopID);
+    Serial.print("Contacting server...");
+    if(client.connect(host, 80)) {
+      Serial.println("OK\r\nRequesting data...");
+      client.print("GET /service/publicXMLFeed?command=predictions&a=");
+      client.print(stops[s].agency);
+      client.print("&r=");
+      client.print(stops[s].route);
+      client.print("&s=");
+      client.print(stops[s].stopID);
+      client.print(" HTTP/1.1\r\nHost: ");
+      client.print(host);
+      client.print("\r\nConnection: Close\r\n\r\n");
+      client.flush();
+      xml.reset();
+      memset(seconds, 0, sizeof(seconds)); // Clear predictions
+      t        = millis(); // Start time
+      timedOut = false;
+      while(client.connected()) {
+        if(!(b++ & 0x40)) refresh(); // Every 64 bytes, handle displays
+        if((c = client.read()) >= 0) {
+          xml.processChar(c);
+          t = millis(); // Reset timeout clock
+        } else if((millis() - t) >= (READ_TIMEOUT * 1000)) {
+          Serial.println("---Timeout---");
+          timedOut = true;
+          break;
+        }
+      }
+      if(!timedOut && seconds[0]) { // Successful transfer?
+        // Copy newly-polled predictions to stops structure:
+        memcpy(stops[s].seconds, seconds, sizeof(seconds));
+        stops[s].lastQueryTime = millis();
+      }
+    }
+    client.stop();
+    Serial.println();
+  }
+}
+

--- a/examples/routefinder.py
+++ b/examples/routefinder.py
@@ -11,7 +11,7 @@ def req(cmd):
 
 	try:
 		proxies = {
-			"http": 'http://45.82.245.34:3128',
+			"http": 'http://45.82.245.34:3128',  # USA
 		}
 
 		headers = {
@@ -42,7 +42,7 @@ def req(cmd):
 # Prompt user for a number in a given range ----------------------------------
 def getNum(prompt, n):
 	while True:
-		nb = input('Enter ' + prompt + ' 0-' + str(n-1) + ': ')
+		nb = input('Enter {0} 0-{1}: '.format(prompt, n - 1))
 		try:                 x = int(nb)
 		except ValueError:   continue    # Ignore non-numbers
 		if x >= 0 and x < n: return x    # and out-of-range values

--- a/examples/routefinder.py
+++ b/examples/routefinder.py
@@ -3,78 +3,104 @@
 # into the predictor program.  Not fancy, just uses text prompts,
 # minimal error checking.
 
-import urllib
+import requests
 from xml.dom.minidom import parseString
 
 # Open connection, issue request, read & parse XML response ------------------
 def req(cmd):
-	connection = urllib.urlopen(
-	  'http://webservices.nextbus.com'  +
-	  '/service/publicXMLFeed?command=' + cmd)
-	raw = connection.read()
-	connection.close()
-	xml = parseString(raw)
-	return xml
+
+	try:
+		proxies = {
+			"http": 'http://45.82.245.34:3128',
+		}
+
+		headers = {
+			"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36 Edg/85.0.564.68"
+		}
+
+		url = 'http://webservices.nextbus.com/service/publicXMLFeed?command=' + cmd
+		print('Request: {0}'.format(url))
+
+		response = requests.get(url, proxies = proxies, headers = headers)
+		if response.status_code == 200:
+			xml = parseString(response.text)
+			return xml
+
+		else:
+			print('Error: {0}'.format(response.status_code))
+			exit(1)
+
+	except requests.exceptions.HTTPError as e:
+		print('Error: {0}'.format(e))
+		exit(1)
+
+	except requests.exceptions.TooManyRedirects as e:
+		print('Error: {0}'.format(e))
+		exit(1)
+
 
 # Prompt user for a number in a given range ----------------------------------
 def getNum(prompt, n):
 	while True:
-		nb = raw_input('Enter ' + prompt + ' 0-' + str(n-1) + ': ')
+		nb = input('Enter ' + prompt + ' 0-' + str(n-1) + ': ')
 		try:                 x = int(nb)
 		except ValueError:   continue    # Ignore non-numbers
 		if x >= 0 and x < n: return x    # and out-of-range values
 
 # Main application -----------------------------------------------------------
 
-# Get list of transit agencies, prompt user for selection, get agency tag.
-dom       = req('agencyList')
-elements  = dom.getElementsByTagName('agency')
-print 'TRANSIT AGENCIES:'
-for i, item in enumerate(elements):
-	print str(i) + ') ' + item.getAttribute('title')
-n         = getNum('transit agency', len(elements))
-agencyTag = elements[n].getAttribute('tag')
+def main():
+	# Get list of transit agencies, prompt user for selection, get agency tag.
+	dom       = req('agencyList')
+	elements  = dom.getElementsByTagName('agency')
+	print('TRANSIT AGENCIES:')
+	for i, item in enumerate(elements):
+		print('{0}) {1}'.format(i, item.getAttribute('title')))
+	n         = getNum('transit agency', len(elements))
+	agencyTag = elements[n].getAttribute('tag')
 
-# Get list of routes for selected agency, prompt user, get route tag.
-dom       = req('routeList&a=' + agencyTag)
-elements  = dom.getElementsByTagName('route')
-print '\nROUTES:'
-for i, item in enumerate(elements):
-	print str(i) + ') ' + item.getAttribute('title')
-n         = getNum('route', len(elements))
-routeTag  = elements[n].getAttribute('tag')
+	# Get list of routes for selected agency, prompt user, get route tag.
+	dom       = req('routeList&a=' + agencyTag)
+	elements  = dom.getElementsByTagName('route')
+	print('\nROUTES:')
+	for i, item in enumerate(elements):
+		print('{0}) {1}'.format(i, item.getAttribute('title')))
+	n         = getNum('route', len(elements))
+	routeTag  = elements[n].getAttribute('tag')
 
-# Get list of directions for selected agency & route, prompt user...
-dom       = req('routeConfig&a=' + agencyTag + '&r=' + routeTag)
-elements  = dom.getElementsByTagName('direction')
-print
-print '\nDIRECTIONS:'
-for i, item in enumerate(elements):
-	print str(i) + ') ' + item.getAttribute('title')
-n         = getNum('direction', len(elements))
-dirTitle  = elements[n].getAttribute('title') # Save for later
-# ...then get list of stop numbers and descriptions -- these are
-# nested in different parts of the XML and must be cross-referenced
-stopNums  = elements[n].getElementsByTagName('stop')
-stopDescs = dom.getElementsByTagName('stop')
+	# Get list of directions for selected agency & route, prompt user...
+	dom       = req('routeConfig&a=' + agencyTag + '&r=' + routeTag)
+	elements  = dom.getElementsByTagName('direction')
+	print('\nDIRECTIONS:')
+	for i, item in enumerate(elements):
+		print('{0}) {1}'.format(i, item.getAttribute('title')))
+	n         = getNum('direction', len(elements))
+	dirTitle  = elements[n].getAttribute('title') # Save for later
+	# ...then get list of stop numbers and descriptions -- these are
+	# nested in different parts of the XML and must be cross-referenced
+	stopNums  = elements[n].getElementsByTagName('stop')
+	stopDescs = dom.getElementsByTagName('stop')
 
-# Cross-reference stop numbers and descriptions to provide a readable
-# list of available stops for selected agency, route & direction.
-# Prompt user for stop number and get corresponding stop tag.
-print '\nSTOPS:'
-for i, item in enumerate(stopNums):
-	stopNumTag = item.getAttribute('tag')
-	for d in stopDescs:
-		stopDescTag = d.getAttribute('tag')
-		if stopNumTag == stopDescTag:
-			print str(i) + ') ' + d.getAttribute('title')
-			break
-n         = getNum('stop', len(stopNums))
-stopTag   = stopNums[n].getAttribute('tag')
+	# Cross-reference stop numbers and descriptions to provide a readable
+	# list of available stops for selected agency, route & direction.
+	# Prompt user for stop number and get corresponding stop tag.
+	print('\nSTOPS:')
+	for i, item in enumerate(stopNums):
+		stopNumTag = item.getAttribute('tag')
+		for d in stopDescs:
+			stopDescTag = d.getAttribute('tag')
+			if stopNumTag == stopDescTag:
+				print('{0}) {1}'.format(i, d.getAttribute('title')))
+				break
+	n         = getNum('stop', len(stopNums))
+	stopTag   = stopNums[n].getAttribute('tag')
 
-# The prediction server wants the stop tag, NOT the stop ID, not sure
-# what's up with that.
+	# The prediction server wants the stop tag, NOT the stop ID, not sure
+	# what's up with that.
 
-print '\nCOPY/PASTE INTO ARDUINO SKETCH:'
-print ('  { 0x70, "' + agencyTag + '", "' + routeTag + '", "' + stopTag +
-  '" }, // ' + dirTitle)
+	print('\nCOPY/PASTE INTO ARDUINO SKETCH:')
+	print('  {{ 0x70, "{0}", "{1}", "{2}" }}, // {3}'.format(agencyTag, routeTag, stopTag, dirTitle))
+
+
+if __name__ == "__main__" :
+	main()

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TinyXML
-version=1.0.1
+version=1.1.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Fork of Adam Rudd's (adamvr) TinyXML library.


### PR DESCRIPTION
Make callback bind-able.

Example of using:
```c++
  xml.init((uint8_t *)buffer, sizeof(buffer), [](uint8_t statusflags, char* tagName, uint16_t tagNameLen, char* data, uint16_t dataLen) {
    if((statusflags & STATUS_ATTR_TEXT) && !strcasecmp(tagName, "seconds")) {
      uint32_t t = atoi(data); // Prediction in seconds (0 if gibberish)
      Serial.print(t); Serial.println(" seconds");
      if(t >= (MIN_TIME * 60)) {        // Above our "too soon" threshold?
        if(!seconds[0]) {               //  No predictions yet?
          seconds[0] = t;               //   Save in slot 0, done
        } else {                        //  Else 1-2 existing predictions...
          if(t <= seconds[0]) {         // New time sooner than slot 0?
            seconds[1] = seconds[0];    //  Move 0 up to 1 (old 1 discarded)
            seconds[0] = t;             //  Store new time in 0
          } else if(!seconds[1] ||      // Slot 1 empty?
                   (t <= seconds[1])) { // Or new time sooner than 1?
            seconds[1] = t;             //  Store new time in slot 1
          }                             // Else discard
          if(seconds[0] == seconds[1]) seconds[1] = 0; // If equal, delete 1
        }
      }
    }
  });
```
