### PR TITLE
Fix tagCount error handling by making it signed

### DIFF
--- a/TinyXML.h
+++ b/TinyXML.h
@@ -32,7 +32,7 @@ private:
   uint8_t currentState;
   uint8_t matchQuote;
   uint8_t LTCount;
-  uint8_t tagCount;
+  int8_t tagCount;
   uint8_t* dataBuffer;
   uint16_t maxDataLen;
   uint16_t dataBufferPtr;


### PR DESCRIPTION
Errorhandling for tagCount is based on checking if it is < 0 which will never happen with a uint8_t, so I made it a int8_t
